### PR TITLE
Extend size of fields, as these can get longer in instagram.

### DIFF
--- a/src/Model/InstagramMediaObject.php
+++ b/src/Model/InstagramMediaObject.php
@@ -36,9 +36,9 @@ class InstagramMediaObject extends Image
     private static $db = array(
         'Title' => 'Varchar',
         'InstagramID' => 'Varchar', // id
-        'InstagramCaptionText' => 'Varchar', // caption
+        'InstagramCaptionText' => 'Varchar(2200)', // caption
         'InstagramMediaType' => 'Varchar', // media_type
-        'InstagramImageURL' => 'Varchar', // media_url
+        'InstagramImageURL' => 'Varchar(400)', // media_url
         'InstagramLink' => 'Varchar', // permalink
         'InstagramCreated' => 'Datetime', // timestamp
         'InstagramUserName' => 'Varchar', // username


### PR DESCRIPTION
My images didn't work and I found out that my image urls were longer than standard varchar fields (specifically 292 characters in my case). So I propose to extend the size of the fields. Link and username could be reduced.