### PR TITLE
Extended link field.

### DIFF
--- a/src/Model/InstagramMediaObject.php
+++ b/src/Model/InstagramMediaObject.php
@@ -39,7 +39,7 @@ class InstagramMediaObject extends Image
         'InstagramCaptionText' => 'Text', // caption
         'InstagramMediaType' => 'Varchar', // media_type
         'InstagramImageURL' => 'Text', // media_url
-        'InstagramLink' => 'Varchar', // permalink
+        'InstagramLink' => 'Varchar(1000)', // permalink
         'InstagramCreated' => 'Datetime', // timestamp
         'InstagramUserName' => 'Varchar', // username
     );


### PR DESCRIPTION
Link field was too small for the instagram link hash.